### PR TITLE
Fixed Brig Physician access

### DIFF
--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -208,7 +208,7 @@
 	supervisors = "the head of security"
 	department_head = list("Head of Security")
 	selection_color = "#ffeeee"
-	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics)
+	access = list(access_medical, access_morgue, access_surgery, access_chemistry, access_virology, access_genetics, access_security, access_sec_doors, access_brig, access_court, access_maint_tunnels)
 	minimal_access = list(access_medical, access_morgue, access_surgery, access_security, access_sec_doors, access_brig, access_court, access_maint_tunnels)
 	outfit = /datum/outfit/job/brigdoc
 


### PR DESCRIPTION
Added the following areas to the BP's list: Brig, Court, Security, Maintenance. They now match the security officer's clearance, save for weapons. (And the medical stuff, of course.)