### PR TITLE
BETA: Modify flash_eyes proc

### DIFF
--- a/code/game/gamemodes/cult/talisman.dm
+++ b/code/game/gamemodes/cult/talisman.dm
@@ -249,18 +249,19 @@
 			target.visible_message("<span class='warning'>[target]'s holy weapon absorbs the talisman's light!</span>", \
 								   "<span class='userdanger'>Your holy weapon absorbs the blinding light!</span>")
 		else
-			target.Weaken(10)
-			target.Stun(10)
-			target.flash_eyes(1,1)
-			if(issilicon(target))
-				var/mob/living/silicon/S = target
-				S.emp_act(1)
-			if(iscarbon(target))
-				var/mob/living/carbon/C = target
-				C.AdjustSilence(5)
-				C.AdjustStuttering(15)
-				C.AdjustCultSlur(20)
-				C.Jitter(15)
+			if(!target.noeyes)
+				target.Weaken(10)
+				target.Stun(10)
+				target.flash_eyes(1,1)
+				if(issilicon(target))
+					var/mob/living/silicon/S = target
+					S.emp_act(1)
+				if(iscarbon(target))
+					var/mob/living/carbon/C = target
+					C.AdjustSilence(5)
+					C.AdjustStuttering(15)
+					C.AdjustCultSlur(20)
+					C.Jitter(15)
 		user.drop_item()
 		qdel(src)
 		return

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -72,11 +72,12 @@
 		if(get_dist(src, L) > range)
 			continue
 
-		if(L.flash_eyes(affect_silicon = 1))
-			L.Weaken(strength)
-			if(L.weakeyes)
-				L.Weaken(strength * 1.5)
-				L.visible_message("<span class='disarm'><b>[L]</b> gasps and shields their eyes!</span>")
+		if(!L.noeyes)
+			if(L.flash_eyes(affect_silicon = 1))
+				L.Weaken(strength)
+				if(L.weakeyes)
+					L.Weaken(strength * 1.5)
+					L.visible_message("<span class='disarm'><b>[L]</b> gasps and shields their eyes!</span>")
 
 /obj/machinery/flasher/emp_act(severity)
 	if(stat & (BROKEN|NOPOWER))

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -83,32 +83,39 @@
 /obj/item/device/flash/proc/flash_carbon(var/mob/living/carbon/M, var/mob/user = null, var/power = 5, targeted = 1)
 	add_logs(user, M, "flashed", object="[src.name]")
 	if(user && targeted)
-		if(M.weakeyes)
-			M.Weaken(3) //quick weaken bypasses eye protection but has no eye flash
-		if(M.flash_eyes(1, 1))
-			M.AdjustConfused(power)
-			terrible_conversion_proc(M, user)
-			M.Stun(1)
-			visible_message("<span class='disarm'>[user] blinds [M] with the flash!</span>")
-			to_chat(user, "<span class='danger'>You blind [M] with the flash!</span>")
-			to_chat(M, "<span class='userdanger'>[user] blinds you with the flash!</span>")
-			if(M.weakeyes)
-				M.Stun(2)
-				M.visible_message("<span class='disarm'>[M] gasps and shields their eyes!</span>", "<span class='userdanger'>You gasp and shields your eyes!</span>")
-		else
+		if(M.noeyes)
 			visible_message("<span class='disarm'>[user] fails to blind [M] with the flash!</span>")
-			to_chat(user, "<span class='warning'>You fail to blind [M] with the flash!</span>")
-			to_chat(M, "<span class='danger'>[user] fails to blind you with the flash!</span>")
+			to_chat(user, "<span class='warning'>The flash is ineffective against someone with no eyes!</span>")
+			to_chat(M, "<span class='danger'>[user] tried to flash you, but didn't realize you have no eyes!</span>")
+		else
+			if(M.weakeyes)
+				M.Weaken(3) //quick weaken bypasses eye protection but has no eye flash
+			if(M.flash_eyes(1, 1))
+				M.AdjustConfused(power)
+				terrible_conversion_proc(M, user)
+				M.Stun(1)
+				visible_message("<span class='disarm'>[user] blinds [M] with the flash!</span>")
+				to_chat(user, "<span class='danger'>You blind [M] with the flash!</span>")
+				to_chat(M, "<span class='userdanger'>[user] blinds you with the flash!</span>")
+				if(M.weakeyes)
+					M.Stun(2)
+					M.visible_message("<span class='disarm'>[M] gasps and shields their eyes!</span>", "<span class='userdanger'>You gasp and shields your eyes!</span>")
+			else
+				visible_message("<span class='disarm'>[user] fails to blind [M] with the flash!</span>")
+				to_chat(user, "<span class='warning'>You fail to blind [M] with the flash!</span>")
+				to_chat(M, "<span class='danger'>[user] fails to blind you with the flash!</span>")
 	else
-		if(M.flash_eyes())
-			M.AdjustConfused(power)
+		if(!M.noeyes)
+			if(M.flash_eyes())
+				M.AdjustConfused(power)
 
 /obj/item/device/flash/attack(mob/living/M, mob/user)
 	if(!try_use_flash(user))
 		return 0
 
 	if(iscarbon(M))
-		flash_carbon(M, user, 5, 1)
+		if(!M.noeyes)
+			flash_carbon(M, user, 5, 1)
 		if(overcharged)
 			M.adjust_fire_stacks(6)
 			M.IgniteMob()
@@ -138,14 +145,16 @@
 		return 0
 	user.visible_message("<span class='disarm'>[user]'s [src.name] emits a blinding light!</span>", "<span class='danger'>Your [src.name] emits a blinding light!</span>")
 	for(var/mob/living/carbon/M in oviewers(3, null))
-		flash_carbon(M, user, 3, 0)
+		if(!M.noeyes)
+			flash_carbon(M, user, 3, 0)
 
 
 /obj/item/device/flash/emp_act(severity)
 	if(!try_use_flash())
 		return 0
 	for(var/mob/living/carbon/M in viewers(3, null))
-		flash_carbon(M, null, 10, 0)
+		if(!M.noeyes)
+			flash_carbon(M, null, 10, 0)
 	burn_out()
 	..()
 

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -60,7 +60,9 @@
 			return
 
 		if(M == user)	//they're using it on themselves
-			if(M.flash_eyes(visual = 1))
+			if(!M.noeyes)
+				M.visible_message("<span class='notice'>You don't have any eyes to wave the light into.</span>")
+			else if(M.flash_eyes(visual = 1))
 				M.visible_message("<span class='notice'>[M] directs [src] to \his eyes.</span>", \
 									 "<span class='notice'>You wave the light in front of your eyes! Trippy!</span>")
 			else
@@ -73,7 +75,9 @@
 
 			if(istype(H)) //robots and aliens are unaffected
 				var/obj/item/organ/internal/eyes/eyes = H.get_int_organ(/obj/item/organ/internal/eyes)
-				if(M.stat == DEAD || !eyes || M.disabilities & BLIND)	//mob is dead or fully blind
+				if(M.noeyes)
+					to_chat(user, "<span class='notice'>[M] doesn't have any eyes!</span>")
+				else if(M.stat == DEAD || !eyes || M.disabilities & BLIND)	//mob is dead or fully blind
 					to_chat(user, "<span class='notice'>[M]'s pupils are unresponsive to the light!</span>")
 				else if((XRAY in M.mutations) || (eyes.colourblind_darkview && eyes.colourblind_darkview == eyes.get_dark_view())) //The mob's either got the X-RAY vision or has a tapetum lucidum (extreme nightvision, i.e. Vulp/Tajara with COLOURBLIND & their monkey forms).
 					to_chat(user, "<span class='notice'>[M]'s pupils glow eerily!</span>")

--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -107,8 +107,10 @@
 			else if(prob(50))
 				severity = 0
 
+			if(!C.noeyes)
+				outmsg = "<span class='notice'>You shine [src] at [C]'s head but they have no eyes!</span>"
 			//20% chance to actually hit the eyes
-			if(prob(effectchance * diode.rating) && C.flash_eyes(severity))
+			else if(prob(effectchance * diode.rating) && C.flash_eyes(severity))
 				outmsg = "<span class='notice'>You blind [C] by shining [src] in their eyes.</span>"
 				if(C.weakeyes)
 					C.Stun(1)

--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -35,21 +35,22 @@
 	var/distance = max(1,get_dist(src,T))
 
 //Flash
-	if(M.weakeyes)
-		M.visible_message("<span class='disarm'><b>[M]</b> screams and collapses!</span>")
-		to_chat(M, "<span class='userdanger'><font size=3>AAAAGH!</font></span>")
-		M.Weaken(15) //hella stunned
-		M.Stun(15)
-		if(ishuman(M))
-			M.emote("scream")
-			var/mob/living/carbon/human/H = M
-			var/obj/item/organ/internal/eyes/E = H.get_int_organ(/obj/item/organ/internal/eyes)
-			if(E)
-				E.receive_damage(8, 1)
+	if(!M.noeyes) //Check if they have eyes first
+		if(M.weakeyes)
+			M.visible_message("<span class='disarm'><b>[M]</b> screams and collapses!</span>")
+			to_chat(M, "<span class='userdanger'><font size=3>AAAAGH!</font></span>")
+			M.Weaken(15) //hella stunned
+			M.Stun(15)
+			if(ishuman(M))
+				M.emote("scream")
+				var/mob/living/carbon/human/H = M
+				var/obj/item/organ/internal/eyes/E = H.get_int_organ(/obj/item/organ/internal/eyes)
+				if(E)
+					E.receive_damage(8, 1)
 
-	if(M.flash_eyes(affect_silicon = 1))
-		M.Stun(max(10/distance, 3))
-		M.Weaken(max(10/distance, 3))
+		if(M.flash_eyes(affect_silicon = 1))
+			M.Stun(max(10/distance, 3))
+			M.Weaken(max(10/distance, 3))
 
 
 //Bang

--- a/code/game/objects/items/weapons/grenades/spawnergrenade.dm
+++ b/code/game/objects/items/weapons/grenades/spawnergrenade.dm
@@ -16,7 +16,8 @@
 			var/turf/T = get_turf(src)
 			playsound(T, 'sound/effects/phasein.ogg', 100, 1)
 			for(var/mob/living/carbon/C in viewers(T, null))
-				C.flash_eyes()
+				if(!C.noeyes)
+					C.flash_eyes()
 
 			for(var/i=1, i<=deliveryamt, i++)
 				var/atom/movable/x = new spawner_type

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -464,7 +464,8 @@
 		reagents.remove_reagent("fuel", amount)
 		check_fuel()
 		if(M)
-			M.flash_eyes(light_intensity)
+			if(!M.noeyes)
+				M.flash_eyes(light_intensity)
 		return TRUE
 	else
 		if(M)

--- a/code/modules/events/anomaly_bluespace.dm
+++ b/code/modules/events/anomaly_bluespace.dm
@@ -37,8 +37,9 @@
 
 				var/list/flashers = list()
 				for(var/mob/living/carbon/C in viewers(TO, null))
-					if(C.flash_eyes())
-						flashers += C
+					if(!C.noeyes)
+						if(C.flash_eyes())
+							flashers += C
 
 				var/y_distance = TO.y - FROM.y
 				var/x_distance = TO.x - FROM.x

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1019,7 +1019,7 @@
 			var/obj/item/clothing/mask/M = H.wear_mask
 			if(M && (M.flags_cover & MASKCOVERSMOUTH))
 				return
-			if(NO_BREATHE in species.species_traits)
+			if(NO_BREATHE in H.species.species_traits)
 				return //no puking if you can't smell!
 			// Humans can lack a mind datum, y'know
 			if(H.mind && (H.mind.assigned_role == "Detective" || H.mind.assigned_role == "Coroner"))

--- a/code/modules/mob/living/carbon/human/species/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station.dm
@@ -622,6 +622,8 @@
 	species_abilities = list(
 		/mob/living/carbon/human/proc/regrow_limbs
 		)
+/datum/species/goo_dragon/handle_life(var/mob/living/carbon/human/H)
+	H.noeyes = 1
 
 /datum/species/goo_dragon/handle_death(var/mob/living/carbon/human/H)
 	H.stop_tail_wagging(1)
@@ -632,6 +634,9 @@
 #define SLIMEPERSON_COLOR_SHIFT_TRIGGER 0.1
 #define SLIMEPERSON_ICON_UPDATE_PERIOD 200 // 20 seconds
 #define SLIMEPERSON_BLOOD_SCALING_FACTOR 5 // Used to adjust how much of an effect the blood has on the rate of color change. Higher is slower.
+
+	H.noeyes = 1 //No eyes, cannot be blinded.
+
 	// Slowly shifting to the color of the reagents
 	if((H in recolor_list) && H.reagents.total_volume > SLIMEPERSON_COLOR_SHIFT_TRIGGER)
 		var/blood_amount = H.blood_volume

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -776,6 +776,9 @@
 
 //called when the mob receives a bright flash
 /mob/living/proc/flash_eyes(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0, type = /obj/screen/fullscreen/flash)
+	var/obj/item/organ/internal/eyes/E = get_int_organ(/obj/item/organ/internal/eyes)
+	if(!E || (E && E.weld_proof)) //if mob has no eyes or has weldproof eyes, do not flash the screen. DOES NOT NEGATE STUN EFFECTS.
+		return 1
 	if(check_eye_prot() < intensity && (override_blindness_check || !(disabilities & BLIND)))
 		overlay_fullscreen("flash", type)
 		addtimer(src, "clear_fullscreen", 25, FALSE, "flash", 25)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -776,9 +776,6 @@
 
 //called when the mob receives a bright flash
 /mob/living/proc/flash_eyes(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0, type = /obj/screen/fullscreen/flash)
-	var/obj/item/organ/internal/eyes/E = get_int_organ(/obj/item/organ/internal/eyes)
-	if(!E || (E && E.weld_proof)) //if mob has no eyes or has weldproof eyes, do not flash the screen. DOES NOT NEGATE STUN EFFECTS.
-		return 1
 	if(check_eye_prot() < intensity && (override_blindness_check || !(disabilities & BLIND)))
 		overlay_fullscreen("flash", type)
 		addtimer(src, "clear_fullscreen", 25, FALSE, "flash", 25)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -157,6 +157,7 @@
 
 	var/digitalcamo = 0 // Can they be tracked by the AI?
 	var/weakeyes = 0 //Are they vulnerable to flashes?
+	var/noeyes = 0 //Do they have eyes?
 
 	var/has_unlimited_silicon_privilege = 0 // Can they interact with station electronics
 

--- a/code/modules/reagents/chemistry/recipes.dm
+++ b/code/modules/reagents/chemistry/recipes.dm
@@ -51,7 +51,8 @@ var/list/chemical_mob_spawn_nicecritters = list() // and possible friendly mobs
 		playsound(get_turf(holder.my_atom), 'sound/effects/phasein.ogg', 100, 1)
 
 		for(var/mob/living/carbon/C in viewers(get_turf(holder.my_atom), null))
-			C.flash_eyes()
+			if(!C.noeyes)
+				C.flash_eyes()
 		for(var/i = 1, i <= amount_to_spawn, i++)
 			var/chosen
 			if(reaction_name == "Friendly Gold Slime")

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -163,11 +163,12 @@ datum/chemical_reaction/flash_powder
 	s.set_up(2, 1, location)
 	s.start()
 	for(var/mob/living/carbon/C in viewers(5, location))
-		if(C.flash_eyes())
-			if(get_dist(C, location) < 4)
-				C.Weaken(5)
-				continue
-			C.Stun(5)
+		if(!C.noeyes)
+			if(C.flash_eyes())
+				if(get_dist(C, location) < 4)
+					C.Weaken(5)
+					continue
+				C.Stun(5)
 	holder.remove_reagent("flash_powder", created_volume)
 
 /datum/chemical_reaction/flash_powder_flash
@@ -183,11 +184,12 @@ datum/chemical_reaction/flash_powder
 	s.set_up(2, 1, location)
 	s.start()
 	for(var/mob/living/carbon/C in viewers(5, location))
-		if(C.flash_eyes())
-			if(get_dist(C, location) < 4)
-				C.Weaken(5)
-				continue
-			C.Stun(5)
+		if(!C.noeyes)
+			if(C.flash_eyes())
+				if(get_dist(C, location) < 4)
+					C.Weaken(5)
+					continue
+				C.Stun(5)
 
 /datum/chemical_reaction/smoke_powder
 	name = "smoke_powder"

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -168,7 +168,8 @@
 	playsound(get_turf(holder.my_atom), 'sound/effects/phasein.ogg', 100, 1)
 
 	for(var/mob/living/carbon/C in viewers(get_turf(holder.my_atom), null))
-		C.flash_eyes()
+		if(!C.noeyes)
+			C.flash_eyes()
 
 	for(var/i = 1, i <= 4 + rand(1,2), i++)
 		var/chosen = pick(borks)
@@ -198,7 +199,8 @@
 	playsound(get_turf(holder.my_atom), 'sound/effects/phasein.ogg', 100, 1)
 
 	for(var/mob/living/carbon/M in viewers(get_turf(holder.my_atom), null))
-		M.flash_eyes()
+		if(!M.noeyes)
+			M.flash_eyes()
 
 	for(var/i = 1, i <= 4 + rand(1,2), i++)
 		var/chosen = pick(borks)


### PR DESCRIPTION
Does not cause the screen to flash if the mob does not have eyes or if the mob's eyes are weldproof (e.g. IPCs). Works as intended for living mobs, needs multiple players for silicon testing (AI, Borg, drone, etc). Does not remove the stagger or drop effects of a flash/flashbang to maintain game balance.