### PR TITLE
Various Vore Fixes

### DIFF
--- a/code/modules/vore/eating/belly_vr.dm
+++ b/code/modules/vore/eating/belly_vr.dm
@@ -247,6 +247,7 @@
 			raw_list[i] = readd_quotes(raw_list[i])
 			//Also fix % sign for var replacement
 			raw_list[i] = replacetext(raw_list[i],"&#37;","%")
+			raw_list[i] = replacetext(raw_list[i],"&#39;","'")
 
 	ASSERT(raw_list.len <= 10) //Sanity
 

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -268,10 +268,10 @@
 		if(0)
 			dat += "<a href='?src=\ref[src];togglemv=1'><span style='color:green;'>Toggle Mob Vore</span></a>"
 
-	dat += "<br><a href='?src=\ref[src];toggle_dropnom_prey=1'>Toggle Drop-nom Prey</a>" //These two get their own, custom row, too.
-	dat += "<a href='?src=\ref[src];toggle_dropnom_pred=1'>Toggle Drop-nom Pred</a>"
+	//dat += "<br><a href='?src=\ref[src];toggle_dropnom_prey=1'>Toggle Drop-nom Prey</a>" //These two get their own, custom row, too. We do not use these
+	//dat += "<a href='?src=\ref[src];toggle_dropnom_pred=1'>Toggle Drop-nom Pred</a>"
 	dat += "<br><a href='?src=\ref[src];setflavor=1'>Set Your Taste</a>"
-	dat += "<a href='?src=\ref[src];togglenoisy=1'>Toggle Hunger Noises</a>"
+	//dat += "<a href='?src=\ref[src];togglenoisy=1'>Toggle Hunger Noises</a>" //Noises are disabled.
 
 	dat += "<HR>"
 
@@ -287,8 +287,8 @@
 	for(var/H in href_list)
 
 	if(href_list["close"])
-		qdel(src)  // Cleanup
 		user.openpanel = 0
+		qdel(src)  // Cleanup
 		return
 
 	if(href_list["show_int"])
@@ -501,8 +501,8 @@
 			selected.items_preserved.Cut() //Re-evaltuate all items in belly on belly-mode change
 
 	if(href_list["b_desc"])
-		var/new_desc = html_encode(input(usr,"Belly Description (1024 char limit):","New Description",selected.inside_flavor) as message|null)
-
+		//var/new_desc = html_encode(input(usr,"Belly Description (1024 char limit):","New Description",selected.inside_flavor) as message|null) //THIS IS BROKEN. DO NOT USE HTML ENCODING
+		var/new_desc = input(usr,"Belly Description (1024 char limit):","New Description",selected.inside_flavor)
 		if(new_desc)
 			new_desc = readd_quotes(new_desc)
 			if(length(new_desc) > BELLIES_DESC_MAX)


### PR DESCRIPTION
Removes drop-nom buttons as they are not used, allows apostrophes to be used in descriptions and belly messages, and stops the vore panel from popping open when closed.